### PR TITLE
feat: handle 'NaN' size

### DIFF
--- a/src/nanoid.ts
+++ b/src/nanoid.ts
@@ -18,6 +18,11 @@ import { urlAlphabet } from "./url_alphabet.ts";
  * @returns {string} A random string.
  */
 function nanoid(size: number = 21): string {
+  if (isNaN(size)) {
+    throw new Deno.errors.InvalidData(
+      "Invalid default size: 'NaN'. Please provide a valid number for the default size.",
+    );
+  }
   // `-=` convert `size` to number to prevent `valueOf` abusing
   fillPool(size -= 0);
   let id: string = "";
@@ -149,6 +154,12 @@ function customRandom(
  * @returns {Uint8Array} An array of random bytes.
  */
 function random(bytes: number): Uint8Array {
+  if (isNaN(bytes)) {
+    throw new Deno.errors.InvalidData(
+      "Invalid bytes size: 'NaN'. Please provide a valid number for the bytes size.",
+    );
+  }
+
   // `-=` convert `bytes` to number to prevent `valueOf` abusing
   fillPool(bytes -= 0);
   return pool.subarray(poolOffset - bytes, poolOffset);

--- a/src/non_secure.ts
+++ b/src/non_secure.ts
@@ -19,6 +19,12 @@ import { urlAlphabet } from "./url_alphabet.ts";
  * @returns {string} A random string.
  */
 function nanoid(size: number = 21): string {
+  if (isNaN(size)) {
+    throw new Deno.errors.InvalidData(
+      "Invalid default size: 'NaN'. Please provide a valid number for the default size.",
+    );
+  }
+
   let id = "";
   // A compact alternative for `for (var i = 0; i < step; i++)`.
   let i = size;

--- a/test/mod.test.ts
+++ b/test/mod.test.ts
@@ -63,6 +63,17 @@ Deno.test("nanoid", async (t) => {
     }
     assertStrictEquals(max - min <= 0.05, true);
   });
+
+  await t.step("throw an error for 'NaN' size", () => {
+    let err: Error | undefined;
+    try {
+      nanoid(NaN);
+    } catch (error) {
+      err = error;
+    } finally {
+      assertIsError(err, Deno.errors.InvalidData, "NaN");
+    }
+  });
 });
 
 Deno.test("customAlphabet", async (t) => {
@@ -170,6 +181,17 @@ Deno.test("random", async (t) => {
       assertStrictEquals(typeof byte, "number");
       assertStrictEquals(byte <= 255, true);
       assertStrictEquals(byte >= 0, true);
+    }
+  });
+
+  await t.step("throw an error for 'NaN' size", () => {
+    let err: Error | undefined;
+    try {
+      random(NaN);
+    } catch (error) {
+      err = error;
+    } finally {
+      assertIsError(err, Deno.errors.InvalidData, "NaN");
     }
   });
 });

--- a/test/non_secure.test.ts
+++ b/test/non_secure.test.ts
@@ -58,6 +58,17 @@ Deno.test("nanoid", async (t) => {
     }
     assertStrictEquals(max - min <= 0.05, true);
   });
+
+  await t.step("throw an error for 'NaN' size", () => {
+    let err: Error | undefined;
+    try {
+      nanoid(NaN);
+    } catch (error) {
+      err = error;
+    } finally {
+      assertIsError(err, Deno.errors.InvalidData, "NaN");
+    }
+  });
 });
 
 Deno.test("customAlphabet", async (t) => {


### PR DESCRIPTION
Do not allow a 'NaN' value for the id size as it may lead to an infinite loop in the function.